### PR TITLE
feat: Treat a 'null' result as success

### DIFF
--- a/.github/workflows/self-smoke-test-action.yml
+++ b/.github/workflows/self-smoke-test-action.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix: {"empty":[]}
+      matrix: ${{ fromJSON('{"empty":[]}') }}
     steps:
     - run: exit 0
 

--- a/.github/workflows/self-smoke-test-action.yml
+++ b/.github/workflows/self-smoke-test-action.yml
@@ -24,6 +24,13 @@ jobs:
     steps:
     - run: exit 0
 
+  empty-matrix:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: {}
+    steps: []
+
   partially-failing-partially-skipped-matrix:
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.rc == '1' }}
@@ -230,6 +237,7 @@ jobs:
     - allow-failures-n-skips
     - allow-skips
     - allow-partials
+    - empty-matrix
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/self-smoke-test-action.yml
+++ b/.github/workflows/self-smoke-test-action.yml
@@ -49,6 +49,7 @@ jobs:
     needs:
     - succeeding-job
     - skipped-job
+    - empty-matrix
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -70,6 +71,7 @@ jobs:
     needs:
     - failing-job
     - skipped-job
+    - empty-matrix
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -92,6 +94,7 @@ jobs:
     - failing-job
     - succeeding-job
     - skipped-job
+    - empty-matrix
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -161,6 +164,7 @@ jobs:
     - failing-job
     - succeeding-job
     - skipped-job
+    - empty-matrix
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -172,7 +176,7 @@ jobs:
       continue-on-error: true
       with:
         allowed-failures: failing-job
-        allowed-skips: skipped-job
+        allowed-skips: skipped-job, empty-matrix
         jobs: ${{ toJSON(needs) }}
     - name: Fail on unexpected outcome (assertion step)
       run: exit 1
@@ -185,6 +189,7 @@ jobs:
     - failing-job
     - succeeding-job
     - skipped-job
+    - empty-matrix
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -195,7 +200,7 @@ jobs:
       id: check
       continue-on-error: true
       with:
-        allowed-skips: failing-job, skipped-job
+        allowed-skips: failing-job, skipped-job, empty-matrix
         jobs: ${{ toJSON(needs) }}
     - name: Fail on unexpected outcome (assertion step)
       run: exit 1
@@ -208,6 +213,7 @@ jobs:
     - failing-job
     - succeeding-job
     - skipped-job
+    - empty-matrix
     - partially-failing-partially-skipped-matrix
     if: always()
     runs-on: ubuntu-latest
@@ -220,7 +226,7 @@ jobs:
       continue-on-error: true
       with:
         allowed-failures: failing-job
-        allowed-skips: skipped-job
+        allowed-skips: skipped-job, empty-matrix
         jobs: ${{ toJSON(needs) }}
     - name: Fail on unexpected outcome (assertion step)
       run: exit 1
@@ -238,7 +244,6 @@ jobs:
     - allow-failures-n-skips
     - allow-skips
     - allow-partials
-    - empty-matrix
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/self-smoke-test-action.yml
+++ b/.github/workflows/self-smoke-test-action.yml
@@ -29,7 +29,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix: {}
-    steps: []
+    steps:
+    - run: exit 0
 
   partially-failing-partially-skipped-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/self-smoke-test-action.yml
+++ b/.github/workflows/self-smoke-test-action.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix: {}
+      matrix: {"empty":[]}
     steps:
     - run: exit 0
 

--- a/src/normalize_needed_jobs_status.py
+++ b/src/normalize_needed_jobs_status.py
@@ -155,10 +155,10 @@ def main(argv):
 
 
     job_matrix_succeeded = all(
-        job['result'] == 'success' for name, job in jobs.items()
+        job['result'] in {'success', 'null'} for name, job in jobs.items()
         if name not in (jobs_allowed_to_fail | jobs_allowed_to_be_skipped)
     ) and all(
-        job['result'] in {'skipped', 'success'} for name, job in jobs.items()
+        job['result'] in {'skipped', 'success', 'null'} for name, job in jobs.items()
         if name in jobs_allowed_to_be_skipped
     )
     set_final_result_outputs(job_matrix_succeeded)
@@ -171,7 +171,7 @@ def main(argv):
 
 
     allowed_to_be_skipped_jobs_succeeded = all(
-        job['result'] == 'success' for name, job in jobs.items()
+        job['result'] in {'success', 'null'} for name, job in jobs.items()
         if name in jobs_allowed_to_be_skipped
     )
 

--- a/src/normalize_needed_jobs_status.py
+++ b/src/normalize_needed_jobs_status.py
@@ -156,7 +156,7 @@ def main(argv):
     with summary_file_path.open(mode=FILE_APPEND_MODE) as summary_file:
         write_lines_to_streams(
             (
-                jobs.items()
+                str(jobs.items())
             ),
             (sys.stderr, summary_file),
         )

--- a/src/normalize_needed_jobs_status.py
+++ b/src/normalize_needed_jobs_status.py
@@ -153,6 +153,13 @@ def main(argv):
             )
         return 1
 
+    with summary_file_path.open(mode=FILE_APPEND_MODE) as summary_file:
+        write_lines_to_streams(
+            (
+                jobs.items()
+            ),
+            (sys.stderr, summary_file),
+        )
 
     job_matrix_succeeded = all(
         job['result'] in {'success', 'null'} for name, job in jobs.items()


### PR DESCRIPTION
But only for jobs listed as allowed to be skipped. A job that doesn't run at all is effectively skipped.